### PR TITLE
Added option for specifying model config in args directly, for programmatic use

### DIFF
--- a/src/lighteval/models/model_config.py
+++ b/src/lighteval/models/model_config.py
@@ -312,8 +312,11 @@ def create_model_config(  # noqa: C901
 
         return BaseModelConfig(**args_dict)
 
-    with open(args.model_config_path, "r") as f:
-        config = yaml.safe_load(f)["model"]
+    if hasattr(args, "model_config") and args.model_config:
+        config = args.model_config["model"]
+    else:
+        with open(args.model_config_path, "r") as f:
+            config = yaml.safe_load(f)["model"]
 
     if config["type"] == "tgi":
         return TGIModelConfig(

--- a/src/lighteval/models/model_config.py
+++ b/src/lighteval/models/model_config.py
@@ -312,6 +312,8 @@ def create_model_config(  # noqa: C901
 
         return BaseModelConfig(**args_dict)
 
+    # This option isn't provided for use via the CLI but rather for programmatic use when constructing the config
+    # in code, so that the config won't need to be saved to a temp file when calling lighteval.
     if hasattr(args, "model_config") and args.model_config:
         config = args.model_config["model"]
     else:


### PR DESCRIPTION
Removed in https://github.com/huggingface/lighteval/pull/187

The parameter was added in order to allow passing the config programmatically without having to save the config directly to a file. 